### PR TITLE
Allow compilation to simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+PlayerSDK/KALTURAPlayerSDK.xcodeproj/xcuserdata
+PlayerSDK/KALTURAPlayerSDK.xcodeproj/project.xcworkspace/xcuserdata

--- a/PlayerSDK/DRMHandler.m
+++ b/PlayerSDK/DRMHandler.m
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Kaltura. All rights reserved.
 //
 
+#if !(TARGET_IPHONE_SIMULATOR)
 #import "DRMHandler.h"
 #import "WViPhoneAPI.h"
 #import "KPLog.h"
@@ -43,3 +44,4 @@ WViOsApiStatus WVCallback( WViOsApiEvent event, NSDictionary *attributes ) {
 
 
 @end
+#endif

--- a/PlayerSDK/KPViewController.m
+++ b/PlayerSDK/KPViewController.m
@@ -156,9 +156,9 @@ typedef NS_ENUM(NSInteger, KPActionType) {
     [self initPlayerParams];
     
     // Pinch Gesture Recognizer - Player Enter/ Exit FullScreen mode
-    UIPinchGestureRecognizer *pinch = [[UIPinchGestureRecognizer alloc] initWithTarget:self
-                                                                                action:@selector(didPinchInOut:)];
-    [self.view addGestureRecognizer:pinch];
+//    UIPinchGestureRecognizer *pinch = [[UIPinchGestureRecognizer alloc] initWithTarget:self
+//                                                                                action:@selector(didPinchInOut:)];
+//    [self.view addGestureRecognizer:pinch];
     
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleEnteredBackground:)

--- a/PlayerSDK/KPViewController.m
+++ b/PlayerSDK/KPViewController.m
@@ -49,7 +49,6 @@ typedef NS_ENUM(NSInteger, KPActionType) {
 @property (nonatomic, strong) KPlayerController *playerController;
 @property (nonatomic) BOOL isModifiedFrame;
 @property (nonatomic) BOOL isFullScreenToggled;
-@property (nonatomic, strong) UIView *superView;
 @end
 
 @implementation KPViewController 
@@ -80,6 +79,10 @@ typedef NS_ENUM(NSInteger, KPActionType) {
     return nil;
 }
 
+- (void)dealloc{
+    [self removePlayer];
+    KPLogInfo(@"Dealloc");
+}
 
 - (void)loadPlayerIntoViewController:(UIViewController *)parentViewController {
     if (parentViewController && [parentViewController isKindOfClass:[UIViewController class]]) {
@@ -107,7 +110,6 @@ typedef NS_ENUM(NSInteger, KPActionType) {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [self.view removeFromSuperview];
     [self removeFromParentViewController];
-    self.superView = nil;
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
@@ -197,8 +199,8 @@ typedef NS_ENUM(NSInteger, KPActionType) {
                     weakSelf.view.frame = [UIScreen mainScreen].bounds;
                     [weakSelf.topWindow addSubview:weakSelf.view];
                 } else {
-                    weakSelf.view.frame = weakSelf.superView.bounds;
-                    [weakSelf.superView addSubview:weakSelf.view];
+                    weakSelf.view.frame = weakSelf.view.superview.bounds;
+                    [weakSelf.view.superview addSubview:weakSelf.view];
                 }
             });
         }
@@ -209,9 +211,6 @@ typedef NS_ENUM(NSInteger, KPActionType) {
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    if (!_superView) {
-        _superView = self.view.superview;
-    }
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
@@ -432,7 +431,7 @@ typedef NS_ENUM(NSInteger, KPActionType) {
     }
     SEL selector = NSSelectorFromString(functionName);
     if ([self respondsToSelector:selector]) {
-        KPLogDebug(@"html5 call::%@ %@",functionName, args);
+        KPLogTrace(@"html5 call::%@ %@",functionName, args);
         [self performSelector:selector withObject:args];
     } else if ([_playerController.player respondsToSelector:selector]) {
         [_playerController.player performSelector:selector withObject:args];
@@ -623,9 +622,6 @@ typedef NS_ENUM(NSInteger, KPActionType) {
     return YES;
 }
 
-- (void)dealloc {
-    KPLogInfo(@"Dealloc");
-}
 @end
 
 

--- a/PlayerSDK/KPlayer.m
+++ b/PlayerSDK/KPlayer.m
@@ -22,7 +22,7 @@ static NSString *StatusKeyPath = @"status";
     id observer;
 }
 @property (nonatomic, strong) AVPlayerLayer *layer;
-@property (nonatomic, strong) UIView *parentView;
+@property (nonatomic, weak) UIView *parentView;
 @end
 
 @implementation KPlayer
@@ -37,6 +37,7 @@ static NSString *StatusKeyPath = @"status";
         _layer.frame = (CGRect){CGPointZero, parentView.frame.size};
         _layer.backgroundColor = [UIColor blackColor].CGColor;
         _parentView = parentView;
+        
         if (parentView.subviews.count) {
             UIWebView *wv = parentView.subviews.lastObject;
             [parentView.subviews.lastObject removeFromSuperview];

--- a/PlayerSDK/KPlayerController.m
+++ b/PlayerSDK/KPlayerController.m
@@ -16,7 +16,7 @@
     BOOL isSeeked;
 }
 
-@property (nonatomic, strong) UIViewController *parentViewController;
+@property (nonatomic, weak) UIViewController *parentViewController;
 @property (nonatomic, strong) KPIMAPlayerViewController *adController;
 @property (nonatomic) BOOL contentEnded;
 @end

--- a/PlayerSDK/PlayerSDK/DeviceParamsHandler.m
+++ b/PlayerSDK/PlayerSDK/DeviceParamsHandler.m
@@ -15,8 +15,7 @@ void setUserAgent() {
     UIWebView* wv = [[UIWebView alloc] initWithFrame:CGRectZero];
     NSString* defaultUA = [wv stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
     NSString* finalUA = [defaultUA stringByAppendingString:suffixUA];
-    NSDictionary *dictionary = [NSDictionary dictionaryWithObjectsAndKeys:finalUA, @"UserAgent", nil];
-    [[NSUserDefaults standardUserDefaults] registerDefaults:dictionary];
+    [[NSUserDefaults standardUserDefaults] setObject: finalUA forKey:@"UserAgent"];
 }
 
 

--- a/PlayerSDK/PlayerSDK/DeviceParamsHandler.m
+++ b/PlayerSDK/PlayerSDK/DeviceParamsHandler.m
@@ -15,7 +15,8 @@ void setUserAgent() {
     UIWebView* wv = [[UIWebView alloc] initWithFrame:CGRectZero];
     NSString* defaultUA = [wv stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
     NSString* finalUA = [defaultUA stringByAppendingString:suffixUA];
-    [[NSUserDefaults standardUserDefaults] setObject: finalUA forKey:@"UserAgent"];
+    NSDictionary *dictionary = [NSDictionary dictionaryWithObjectsAndKeys:finalUA, @"UserAgent", nil];
+    [[NSUserDefaults standardUserDefaults] registerDefaults:dictionary];
 }
 
 

--- a/PlayerSDK/PlayerSDK/DeviceParamsHandler.m
+++ b/PlayerSDK/PlayerSDK/DeviceParamsHandler.m
@@ -11,7 +11,7 @@
 #import "DeviceParamsHandler.h"
 
 void setUserAgent() {
-    NSString* suffixUA = @"kalturaNativeCordovaPlayer";
+    NSString* suffixUA = @" kalturaNativeCordovaPlayer";
     UIWebView* wv = [[UIWebView alloc] initWithFrame:CGRectZero];
     NSString* defaultUA = [wv stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
     NSString* finalUA = [defaultUA stringByAppendingString:suffixUA];

--- a/player-sdk-native-ios.podspec
+++ b/player-sdk-native-ios.podspec
@@ -33,7 +33,7 @@ s.platform     = :ios, "6.0"
 
 
 # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-s.source       = { :git => 'https://github.com/kaltura/player-sdk-native-ios.git', :tag => 'v1.1' }
+s.source       = { :git => 'https://github.com/tbrannam/player-sdk-native-ios.git', :tag => 'v1.1-tbrannam-patch' }
 s.library      = 'stdc++', 'z', 'System', 'stdc++.6', 'xml2.2', 'c++', 'stdc++.6.0.9', 'xml2'
 s.framework    = 'MediaPlayer', 'GoogleCast', 'SystemConfiguration', 'QuartzCore', 'CoreFoundation', 'AVFoundation', 'AudioToolbox', 'CFNetwork', 'AdSupport', 'WebKit', 'MessageUI', 'Social', 'MediaAccessibility', 'Foundation', 'CoreGraphics', 'UIKit'
 

--- a/player-sdk-native-ios.podspec
+++ b/player-sdk-native-ios.podspec
@@ -48,7 +48,7 @@ s.requires_arc = true
 # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 s.source_files  = "PlayerSDK/**/*.{h,m}", "PlayerSDK/PlayerSDK/**/*.{h,m}"
 s.vendored_library = 'PlayerSDK/libWViPhoneAPI.a'
-#s.exclude_files = "Classes/Exclude"
+s.exclude_files = "PlayerSDK/DRMHandler.{h,m}"
 
 # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 #


### PR DESCRIPTION
The DRM component has dependencies on WildVine - which apparently isn't being built against the x86 (simulator) SDK.    Added a !(TARGET_IPHONE_SIMULATOR) to skip implementation for this environment.

Additionally - commented out Pinch Gesture Recognizer - to prevent a runtime crash when calling an non-existant selector fixes: #24 

