### PR TITLE
Fix for display freeze issue on iPad

### DIFF
--- a/KALTURAPlayerSDK/KPIMAPlayerViewController.m
+++ b/KALTURAPlayerSDK/KPIMAPlayerViewController.m
@@ -11,6 +11,8 @@
 #import "KPLog.h"
 #import "IMAHandler.h"
 
+#define IS_IPAD  (UI_USER_INTERFACE_IDIOM()==UIUserInterfaceIdiomPad)
+
 @interface KPIMAPlayerViewController ()
 
 /// Contains the params for the logic layer
@@ -261,6 +263,10 @@
 }
 
 - (void)adsManagerDidRequestContentResume:(id<AdsManager>)adsManager {
+    if (IS_IPAD){
+        [self.adsManager destroy];
+    }
+    
     // The SDK is done playing ads (at least for now), so resume the content.
     [self.contentPlayer play];
     NSDictionary *eventParams = ContentResumeRequestedKey.nullVal;


### PR DESCRIPTION
In the latest kaltura SDK, the videos(with ads) does not auto play on iPad. After playing ads is complete, the display freezes on iPad. 

This can be fixed by releasing ad manager before resuming video.