### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Architecture Overview
 Getting Started
 ======
 
-**KalturaPlayerSDK** can be added to any project (big or small) in a matter of minutes (maybe even seconds if you're super speedy). Cocoapods is fully supported.
+**KalturaPlayerSDK** can be added to any project (big or small) in a matter of minutes (maybe even seconds if you're super speedy). CocoaPods is fully supported.
 
-##SDK Cocoapods Installation :
+##SDK CocoaPods Installation :
 
 The easiest way to install KalturaPlayerSDK is to use <a href="http://cocoapods.org/" target="_blank">CocoaPods</a>. To do so, simply add the following line to your `Podfile`:
 	<pre><code>pod 'KalturaPlayerSDK'</code></pre>
@@ -78,7 +78,7 @@ Make sure to add the _**`KALTURAPlayerSDK.xcodeproj`**_ file only, **not the ent
 
 Linking GoogleCast
 ======
-###Cocoapods support
+###CocoaPods support
 If you are using cocoapods please attach the following to your pod file:
 ```
 	pod 'google-cast-sdk'
@@ -89,7 +89,7 @@ If you are using cocoapods please attach the following to your pod file:
 
 Linking GoogleAds
 ======
-###Cocoapods support
+###CocoaPods support
 If you are using cocoapods please attach the following to your pod file:
 ```
    	pod 'Google-Mobile-Ads-SDK'


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
