### PR TITLE
Subtitle & Closed caption support [please merge after the audio track pull]

### DIFF
--- a/KALTURAPlayerSDK/KPViewController.m
+++ b/KALTURAPlayerSDK/KPViewController.m
@@ -826,6 +826,9 @@ NSString *const KPErrorDomain = @"com.kaltura.player";
         case audioTrackSelected:
             [_playerFactory selectAudioTrack:[attributeVal integerValue]];
             break;
+        case textTrackSelected:
+            [_playerFactory selectTextTrack:attributeVal];
+            break;
         case playerError:
             if ([_delegate respondsToSelector:@selector(kPlayer:didFailWithError:)]) {
                 NSDictionary *dict = @{NSLocalizedDescriptionKey:attributeVal,

--- a/KALTURAPlayerSDK/KPViewController.m
+++ b/KALTURAPlayerSDK/KPViewController.m
@@ -823,6 +823,9 @@ NSString *const KPErrorDomain = @"com.kaltura.player";
         case visible:
             [self visible: attributeVal];
             break;
+        case audioTrackSelected:
+            [_playerFactory selectAudioTrack:[attributeVal integerValue]];
+            break;
         case playerError:
             if ([_delegate respondsToSelector:@selector(kPlayer:didFailWithError:)]) {
                 NSDictionary *dict = @{NSLocalizedDescriptionKey:attributeVal,

--- a/KALTURAPlayerSDK/KPViewControllerProtocols.h
+++ b/KALTURAPlayerSDK/KPViewControllerProtocols.h
@@ -41,7 +41,8 @@ typedef enum{
     doubleClickRequestAds,
     language,
     captions,
-    audioTrackSelected
+    audioTrackSelected,
+    textTrackSelected
 } Attribute;
 
 @protocol KPlayerDelegate;
@@ -55,6 +56,8 @@ typedef enum{
 @property (nonatomic) float volume NS_AVAILABLE(10_7, 7_0);
 @property (nonatomic, getter=isMuted) BOOL mute NS_AVAILABLE(10_7, 7_0);
 @property (nonatomic, readonly) BOOL isKPlayer;
+@property (nonatomic) BOOL preferSubtitles;
+
 
 
 - (instancetype)initWithParentView:(UIView *)parentView;
@@ -71,7 +74,9 @@ typedef enum{
 - (void)changeSubtitleLanguage:(NSString *)languageCode;
 - (void)setSourceWithAsset:(AVURLAsset*)asset;
 - (void)hidePlayer;
-- (void)selectAudioTrack:(int)audioTrack;
+- (void)selectAudioTrack:(int)trackId;
+- (void)selectTextTrack:(NSString *)locale;
+
 
 @end
 

--- a/KALTURAPlayerSDK/KPViewControllerProtocols.h
+++ b/KALTURAPlayerSDK/KPViewControllerProtocols.h
@@ -40,7 +40,8 @@ typedef enum{
     nativeAction,
     doubleClickRequestAds,
     language,
-    captions
+    captions,
+    audioTrackSelected
 } Attribute;
 
 @protocol KPlayerDelegate;
@@ -70,6 +71,7 @@ typedef enum{
 - (void)changeSubtitleLanguage:(NSString *)languageCode;
 - (void)setSourceWithAsset:(AVURLAsset*)asset;
 - (void)hidePlayer;
+- (void)selectAudioTrack:(int)audioTrack;
 
 @end
 

--- a/KALTURAPlayerSDK/KPlayer.m
+++ b/KALTURAPlayerSDK/KPlayer.m
@@ -217,12 +217,15 @@ NSString * const StatusKeyPath = @"status";
 
         for (AVMediaSelectionOption *option in group.options){
             NSString *langCode = [option.locale objectForKey:NSLocaleLanguageCode];
+            if (langCode == nil){
+                langCode = @"en";
+            }
             if ([option hasMediaCharacteristic:AVMediaCharacteristicContainsOnlyForcedSubtitles]){
                  [subtitles addObject:@{@"kind": @"subtitle",
                                  @"language": langCode,
                                  @"scrlang": langCode,
                                  @"label": langCode,
-                                 @"index": @(captions.count),
+                                 @"index": @(subtitles.count),
                                  @"title": option.displayName}];
             }else{
                 [captions addObject:@{@"kind": @"subtitle",
@@ -233,12 +236,17 @@ NSString * const StatusKeyPath = @"status";
                                       @"title": option.displayName}];
             }
         }
-        NSMutableDictionary *languages = @{@"languages": subtitles}.mutableCopy;
-        NSMutableDictionary *closedCaptionLanguages = @{@"languages": captions}.mutableCopy;
+        if ([subtitles count] > 0){
+            NSMutableDictionary *languages = @{@"languages": subtitles}.mutableCopy;
+            [self.delegate player:self eventName:@"textTracksReceived" JSON:languages.toJSON];
 
-            
-        [self.delegate player:self eventName:@"textTracksReceived" JSON:languages.toJSON];
-        [self.delegate player:self eventName:@"closedCaptionsRecived" JSON:closedCaptionLanguages.toJSON];
+
+        }
+        if ([captions count] > 0){
+           NSMutableDictionary *closedCaptionLanguages = @{@"languages": captions}.mutableCopy;
+           [self.delegate player:self eventName:@"closedCaptionsRecived" JSON:closedCaptionLanguages.toJSON];
+        }
+       
 
     }
 }
@@ -290,10 +298,12 @@ NSString * const StatusKeyPath = @"status";
                                      @"index": @(audioTracks.count)
                                      }];
         }
-        NSMutableDictionary *audioLanguages = @{@"languages": audioTracks}.mutableCopy;
-        [self.delegate player:self
+        if ([audioTracks count] > 0){
+          NSMutableDictionary *audioLanguages = @{@"languages": audioTracks}.mutableCopy;
+          [self.delegate player:self
                     eventName:@"audioTracksReceived"
                          JSON:audioLanguages.toJSON];
+        }
     }
   
 }

--- a/KALTURAPlayerSDK/KPlayerFactory.h
+++ b/KALTURAPlayerSDK/KPlayerFactory.h
@@ -51,6 +51,8 @@ static NSString *PostrollEndedKey = @"postEnded";
 - (void)setAssetParam:(NSString*)key toValue:(id)value;
 - (void)backToForeground;
 - (void)selectAudioTrack:(int)trackId;
+- (void)selectTextTrack:(NSString *)locale;
+
 
 @property (nonatomic, strong) id<KPlayer> player;
 @property (nonatomic, weak) id<KPlayerFactoryDelegate> delegate;
@@ -64,4 +66,6 @@ static NSString *PostrollEndedKey = @"postEnded";
 @property (nonatomic, assign) BOOL isReleasePlayerPositionEnabled;
 @property (nonatomic, strong) KPIMAPlayerViewController *adController;
 @property (nonatomic, strong) id kIMAWebOpenerDelegate;
+@property (nonatomic, assign) BOOL preferSubtitles;
+
 @end

--- a/KALTURAPlayerSDK/KPlayerFactory.h
+++ b/KALTURAPlayerSDK/KPlayerFactory.h
@@ -50,6 +50,7 @@ static NSString *PostrollEndedKey = @"postEnded";
 - (void)prepareForChangeConfiguration;
 - (void)setAssetParam:(NSString*)key toValue:(id)value;
 - (void)backToForeground;
+- (void)selectAudioTrack:(int)trackId;
 
 @property (nonatomic, strong) id<KPlayer> player;
 @property (nonatomic, weak) id<KPlayerFactoryDelegate> delegate;

--- a/KALTURAPlayerSDK/KPlayerFactory.m
+++ b/KALTURAPlayerSDK/KPlayerFactory.m
@@ -43,6 +43,7 @@
     self = [super init];
     if (self) {
         self.playerClassName = className;
+        self.preferSubtitles = YES;
         return self;
     }
     return nil;
@@ -61,6 +62,8 @@
         Class class = NSClassFromString(_playerClassName);
         _player = [(id<KPlayer>)[class alloc] initWithParentView:_parentViewController.view];
         _player.delegate = self;
+        _player.preferSubtitles = self.preferSubtitles;
+        
     }
     return _player;
 }
@@ -77,6 +80,7 @@
 
 - (void)setSrc:(NSString *)src {
     isReady = NO;
+    src = @"https://devimages.apple.com.edgekey.net/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8";
     _src = src;
     
     id<KPlayer> player = _player;
@@ -88,9 +92,15 @@
 }
 
 -(void)selectAudioTrack:(int)trackId{
-    KPLogDebug(@"Change track Id:%@",trackId);
+    KPLogDebug(@"Change audio track Id:%@",trackId);
     [_player selectAudioTrack:trackId];
 }
+
+-(void)selectTextTrack:(NSString*)locale{
+    KPLogDebug(@"Change text track Id:%@",locale);
+    [_player selectTextTrack:locale];
+}
+
 
 -(void)setLicenseUri:(NSString*)licenseUri {
     [_assetBuilder setLicenseUri:licenseUri];

--- a/KALTURAPlayerSDK/KPlayerFactory.m
+++ b/KALTURAPlayerSDK/KPlayerFactory.m
@@ -87,6 +87,11 @@
     [_assetBuilder setContentUrl:src];
 }
 
+-(void)selectAudioTrack:(int)trackId{
+    KPLogDebug(@"Change track Id:%@",trackId);
+    [_player selectAudioTrack:trackId];
+}
+
 -(void)setLicenseUri:(NSString*)licenseUri {
     [_assetBuilder setLicenseUri:licenseUri];
 }

--- a/KALTURAPlayerSDK/KPlayerFactory.m
+++ b/KALTURAPlayerSDK/KPlayerFactory.m
@@ -80,7 +80,6 @@
 
 - (void)setSrc:(NSString *)src {
     isReady = NO;
-    src = @"https://devimages.apple.com.edgekey.net/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8";
     _src = src;
     
     id<KPlayer> player = _player;

--- a/KALTURAPlayerSDK/NSString+Utilities.m
+++ b/KALTURAPlayerSDK/NSString+Utilities.m
@@ -76,8 +76,9 @@ NSString *const LocalContentId = @"localContentId";
                             @"nativeAction",
                             @"doubleClickRequestAds",
                             @"language",
-                            @"textTrackSelected",
-                            @"audioTrackSelected"];
+                            @"captions",
+                            @"audioTrackSelected",
+                              @"textTrackSelected"];
     KPLogTrace(@"Exit");
     return (Attribute)[attributes indexOfObject:self];
 }

--- a/KALTURAPlayerSDK/NSString+Utilities.m
+++ b/KALTURAPlayerSDK/NSString+Utilities.m
@@ -76,7 +76,8 @@ NSString *const LocalContentId = @"localContentId";
                             @"nativeAction",
                             @"doubleClickRequestAds",
                             @"language",
-                            @"textTrackSelected"];
+                            @"textTrackSelected",
+                            @"audioTrackSelected"];
     KPLogTrace(@"Exit");
     return (Attribute)[attributes indexOfObject:self];
 }


### PR DESCRIPTION
Added a new property called preferSubtitles - true by default,
when true we'll not count the closed captions tracks, when false we'll only add closed captions.
we need it to avoid duplications of languages and to let the application developers to choose what should be supported.
in order to activate on the player UI add this configuration :     [config addConfigKey:@"closedCaptions.showEmbeddedCaptions" withValue:@"true"];
