### PR TITLE
Fixes serious issues with registering widevine asset

### DIFF
--- a/KALTURAPlayerSDK/KPLocalAssetsManager.m
+++ b/KALTURAPlayerSDK/KPLocalAssetsManager.m
@@ -152,6 +152,11 @@ typedef NS_ENUM(NSUInteger, kDRMScheme) {
     NSURL *getLicenseDataURL = [self prepareGetLicenseDataURLForAsset:assetConfig
                                                              flavorId:flavorId
                                                             drmScheme:drmScheme];
+    
+    if (!getLicenseDataURL) {
+        return nil;
+    }
+    
     NSData *licenseData = [NSData dataWithContentsOfURL:getLicenseDataURL];
     NSError *jsonError = nil;
     NSDictionary *licenseDataDict = [NSJSONSerialization JSONObjectWithData:licenseData
@@ -195,6 +200,9 @@ typedef NS_ENUM(NSUInteger, kDRMScheme) {
         serverURL = assetConfig.resolvePlayerRootURL;
     }
     
+    if (!serverURL) {
+        return nil;
+    }
     
     // Now serviceURL is something like "http://cdnapi.kaltura.com/html5/html5lib/v2.38.3".
     NSString* drmName = nil; 
@@ -330,6 +338,11 @@ typedef NS_ENUM(NSUInteger, kDRMScheme) {
     // This is done by loading UIConf data, and looking at "html5Url" property.
     
     NSData *jsonData = self.loadUIConf;
+    
+    if (!jsonData) {
+        return nil;
+    }
+    
     NSError *jsonError = nil;
     NSDictionary *uiConf = [NSJSONSerialization JSONObjectWithData:jsonData
                                                            options:0

--- a/KALTURAPlayerSDK/KPLocalAssetsManager.m
+++ b/KALTURAPlayerSDK/KPLocalAssetsManager.m
@@ -317,6 +317,8 @@ typedef NS_ENUM(NSUInteger, kDRMScheme) {
         [items addObject:[KPLocalAssetsManager queryItem:@"ks" :self.ks]];
     }
     
+    urlComps.queryItems = items;
+    
     NSURL* apiCall = urlComps.URL;
     
     return [NSData dataWithContentsOfURL:apiCall];


### PR DESCRIPTION
- Fixes issue where array of queryItems wasn't being included in API call, thus the API call would always return an error. Not sure how this could ever have been tested.
- Also fixes a crash when the request is made while the user is offline.