### PR TITLE
Allow Widevine to be disabled.

### DIFF
--- a/KALTURAPlayerSDK/KPAssetBuilder.m
+++ b/KALTURAPlayerSDK/KPAssetBuilder.m
@@ -46,15 +46,22 @@
 
 +(NSDictionary*)supportedMediaFormats {
     // We support FairPlay and Widevine Classic, as well as clear MP4 and HLS.
-    return @{
-#if TARGET_OS_SIMULATOR             
-             // No DRM support in the simulator.
-             @"all": @[@"hls",@"mp4"],
-             @"drm": @[],
-#else
-             @"all": @[@"hls",@"wvm",@"mp4"],
-             @"drm": @[@"hls",@"wvm"],
+    
+    NSMutableArray* all = [NSMutableArray arrayWithObjects:@"hls", @"mp4", nil];
+    NSMutableArray* drm = [NSMutableArray array];
+#if !TARGET_OS_SIMULATOR
+    [drm addObject:@"hls"]; // FairPlay is built-in
+    
+#if WIDEVINE_ENABLED
+    [drm addObject:@"wvm"]; // Widevine is optional
+    [all addObject:@"wvm"];
 #endif
+    
+#endif
+    
+    return @{
+             @"all": [all copy],
+             @"drm": [drm copy],
              };
 }
 

--- a/KALTURAPlayerSDK/WidevineClassicCDM.m
+++ b/KALTURAPlayerSDK/WidevineClassicCDM.m
@@ -22,22 +22,28 @@
 
 @implementation WidevineClassicCDM
 
-#if TARGET_OS_SIMULATOR
-// The widevine library does not support the simulator, so the following are stubs that do nothing.
+#if TARGET_OS_SIMULATOR || !WIDEVINE_ENABLED
+// If the Widevine Classic library is not present, we need to stub it, to satisfy the linker.
 WViOsApiStatus WV_Initialize(const WViOsApiStatusCallback callback, NSDictionary *settings ) {
-    assert(!"FATAL error: Widevine Classic is not avaialble for Simulator");
+    
+    // Help developers find the misconfiguration by crashing.
+#if TARGET_OS_SIMULATOR || DEBUG
+    assert(!"FATAL error: Widevine Classic is not avaialble");
+#endif
+    
     callback(WViOsApiEvent_InitializeFailed, @{}); 
     return WViOsApiStatus_NotInitialized; 
 }
-WViOsApiStatus WV_Terminate() { return WViOsApiStatus_OK; }
-WViOsApiStatus WV_SetCredentials( NSDictionary *settings ) { return WViOsApiStatus_OK; }
-WViOsApiStatus WV_RegisterAsset (NSString *asset) { return WViOsApiStatus_OK; }
-WViOsApiStatus WV_UnregisterAsset (NSString *asset) { return WViOsApiStatus_OK; }
-WViOsApiStatus WV_QueryAssetStatus (NSString *asset ) { return WViOsApiStatus_OK; }
-WViOsApiStatus WV_NowOnline () { return WViOsApiStatus_OK; }
-WViOsApiStatus WV_RenewAsset (NSString *asset) { return WViOsApiStatus_OK; }
-WViOsApiStatus WV_Play (NSString *asset, NSMutableString *url, NSData *authentication ) {[url setString:asset]; return WViOsApiStatus_OK; }
-WViOsApiStatus WV_Stop () { return WViOsApiStatus_OK; }
+
+WViOsApiStatus WV_Terminate() { return WViOsApiStatus_NotInitialized; }
+WViOsApiStatus WV_SetCredentials( NSDictionary *settings ) { return WViOsApiStatus_NotInitialized; }
+WViOsApiStatus WV_RegisterAsset (NSString *asset) { return WViOsApiStatus_NotInitialized; }
+WViOsApiStatus WV_UnregisterAsset (NSString *asset) { return WViOsApiStatus_NotInitialized; }
+WViOsApiStatus WV_QueryAssetStatus (NSString *asset ) { return WViOsApiStatus_NotInitialized; }
+WViOsApiStatus WV_NowOnline () { return WViOsApiStatus_NotInitialized; }
+WViOsApiStatus WV_RenewAsset (NSString *asset) { return WViOsApiStatus_NotInitialized; }
+WViOsApiStatus WV_Play (NSString *asset, NSMutableString *url, NSData *authentication ) {[url setString:asset]; return WViOsApiStatus_NotInitialized; }
+WViOsApiStatus WV_Stop () { return WViOsApiStatus_NotInitialized; }
 NSString *NSStringFromWViOsApiEvent( WViOsApiEvent event ) { return @"Stub"; }
 #endif
 

--- a/KalturaPlayerSDK.podspec
+++ b/KalturaPlayerSDK.podspec
@@ -34,30 +34,24 @@ s.platform     = :ios, "8.0"
 
 # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 s.source       = { :git => 'https://github.com/kaltura/player-sdk-native-ios.git', :tag => 'v' + s.version.to_s }
-s.libraries      = 'stdc++', 'z', 'System', 'stdc++.6', 'xml2.2', 'c++', 'stdc++.6.0.9', 'xml2', 'WViPhoneAPI'
+s.libraries      = 'stdc++', 'z', 'System', 'stdc++.6', 'xml2.2', 'c++', 'stdc++.6.0.9', 'xml2'
 s.framework    = 'MediaPlayer', 'SystemConfiguration', 'QuartzCore', 'CoreFoundation', 'AVFoundation', 'AudioToolbox', 'CFNetwork', 'AdSupport', 'WebKit', 'MessageUI', 'Social', 'MediaAccessibility', 'Foundation', 'CoreGraphics', 'UIKit'
 
 s.requires_arc = true
 
 
-# ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-s.source_files  = "**/*.{h,m}", "PlayerSDK/KALTURAPlayerSDK/**/*.{h,m}"
-s.vendored_library = 'libWViPhoneAPI.a'
-s.resource_bundle = { 'KALTURAPlayerSDKResources' => 'KALTURAPlayerSDK/*.{xib,plist}' }
-#s.exclude_files = "Classes/Exclude"
-
-# ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-#
-#  A list of resources included with the Pod. These are copied into the
-#  target bundle with a build phase script. Anything else will be cleaned.
-#  You can preserve files from being cleaned, please don't preserve
-#  non-essential files like tests, examples and documentation.
-#
-
-# s.resource  = "icon.png"
-# s.resources = "Resources/*.png"
-
-# s.preserve_paths = "FilesToSave", "MoreFilesToSave"
-
-s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
+s.subspec 'Core' do |sp|
+    sp.source_files  = "**/*.{h,m}", "PlayerSDK/KALTURAPlayerSDK/**/*.{h,m}"
+    sp.resource_bundle = { 'KALTURAPlayerSDKResources' => 'KALTURAPlayerSDK/*.{xib,plist}' }
 end
+
+s.subspec 'Widevine' do |sp|
+    sp.libraries = 'WViPhoneAPI'
+    sp.vendored_library = 'libWViPhoneAPI.a'
+    sp.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO', 'GCC_PREPROCESSOR_DEFINITIONS'=>'WIDEVINE_ENABLED=1' }
+end
+
+end
+
+
+


### PR DESCRIPTION
Split our podspec to 2 subspecs - Core and Widevine.
Core contains all source files, INCLUDING Widevine-related files.
Widevine contains the Widevine library and a preprocessor macro WIDEVINE_ENABLED=1.

To use the entire SDK, a client app has to use, as before:
    pod 'KalturaPlayerSDK'

To exclude Widevine, only include the subspec Core:
    pod 'KalturaPlayerSDK/Core'