### PR TITLE
Fix refresh cache.

### DIFF
--- a/KALTURAPlayerSDK/KPLocalAssetsManager.m
+++ b/KALTURAPlayerSDK/KPLocalAssetsManager.m
@@ -313,7 +313,8 @@ typedef NS_ENUM(NSUInteger, kDRMScheme) {
         callback(error);
         [KPURLProtocol disable];
     } else {
-        [[[NSURLSession sharedSession] dataTaskWithURL:url completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        NSURLRequest* req = [NSURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:60];
+        [[[NSURLSession sharedSession] dataTaskWithRequest:req completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
             callback(error);
             [KPURLProtocol disable];
         }] resume];

--- a/KALTURAPlayerSDK/KPURLProtocol.m
+++ b/KALTURAPlayerSDK/KPURLProtocol.m
@@ -122,7 +122,7 @@ static NSString *localContentID = nil;
     NSDictionary *cachedHeaders = requestStr.cachedResponseHeaders;
     NSData *cachedPage = requestStr.cachedPage;
     
-    if (cachedHeaders && cachedPage && cachedPage.length) {
+    if (self.request.cachePolicy!=NSURLRequestReloadIgnoringLocalCacheData && cachedHeaders && cachedPage && cachedPage.length) {
         NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:self.request.URL
                                                                   statusCode:[cachedHeaders[@"statusCode"] integerValue]
                                                                  HTTPVersion:nil


### PR DESCRIPTION
KPURLProtocol: if cachePolicy is NSURLRequestReloadIgnoringLocalCacheData, do not read from cache.
KPLocalAssetsManager: specify cachePolicy=NSURLRequestReloadIgnoringLocalCacheData when refreshing the cache.