### PR TITLE
Added support v.3.2.1 for GoogleADSIMAiOSSDK.

### DIFF
--- a/KALTURAPlayerSDK/IMAHandler.h
+++ b/KALTURAPlayerSDK/IMAHandler.h
@@ -60,8 +60,8 @@
 
 @property (nonatomic, strong) id delegate;
 
-- (void)initializeWithContentPlayhead:(id<AVPlayerContentPlayhead>)contentPlayhead
-                 adsRenderingSettings:(id<AdsRenderingSettings>)adsRenderingSettings;
+- (void)initializeWithAdsRenderingSettings:(id<AdsRenderingSettings>)adsRenderingSettings;
+
 - (void)start;
 - (void)pause;
 - (void)resume;
@@ -98,11 +98,11 @@ typedef NS_ENUM(NSInteger, IMAAdEventType){
      */
     kIMAAdEvent_AD_BREAK_READY,
     /**
-     *  Ad break ended (only used for server side ad insertion).
+     *  Ad break ended (only used for dynamic ad insertion).
      */
     kIMAAdEvent_AD_BREAK_ENDED,
     /**
-     *  Ad break started (only used for server side ad insertion).
+     *  Ad break started (only used for dynamic ad insertion).
      */
     kIMAAdEvent_AD_BREAK_STARTED,
     /**
@@ -117,6 +117,10 @@ typedef NS_ENUM(NSInteger, IMAAdEventType){
      *  Single ad has finished.
      */
     kIMAAdEvent_COMPLETE,
+    /**
+     *  Cuepoints changed for VOD stream (only used for dynamic ad insertion).
+     */
+    kIMAAdEvent_CUEPOINTS_CHANGED,
     /**
      *  First quartile of a linear ad was reached.
      */
@@ -154,7 +158,6 @@ typedef NS_ENUM(NSInteger, IMAAdEventType){
      */
     kIMAAdEvent_THIRD_QUARTILE
 };
-
 
 @protocol AdPodInfo <NSObject>
 

--- a/KALTURAPlayerSDK/KPIMAPlayerViewController.m
+++ b/KALTURAPlayerSDK/KPIMAPlayerViewController.m
@@ -160,8 +160,8 @@
     self.adsManager = adsLoadedData.adsManager;
     self.adsManager.delegate = self;
     // Initialize the ads manager.
-    [self.adsManager initializeWithContentPlayhead:self.playhead
-                              adsRenderingSettings:self.adsRenderingSettings];
+    
+    [self.adsManager initializeWithAdsRenderingSettings: self.adsRenderingSettings];
     
     NSDictionary *eventParams = AdLoadedEventKey.nullVal;
     [self.delegate player:nil


### PR DESCRIPTION
Added support v.3.2.1 for FEM-765 Disney - not been able to load google’s doubleclick test appAdTagUrl.