### PR TITLE
Try a different way of ignoring local cache of a specific request.

### DIFF
--- a/KALTURAPlayerSDK/KPLocalAssetsManager.m
+++ b/KALTURAPlayerSDK/KPLocalAssetsManager.m
@@ -313,7 +313,9 @@ typedef NS_ENUM(NSUInteger, kDRMScheme) {
         callback(error);
         [KPURLProtocol disable];
     } else {
-        NSURLRequest* req = [NSURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:60];
+        NSMutableURLRequest* req = [NSMutableURLRequest requestWithURL:url];
+        [KPURLProtocol ignoreLocalCacheForRequest:req];
+        
         [[[NSURLSession sharedSession] dataTaskWithRequest:req completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
             callback(error);
             [KPURLProtocol disable];

--- a/KALTURAPlayerSDK/KPURLProtocol.h
+++ b/KALTURAPlayerSDK/KPURLProtocol.h
@@ -11,4 +11,5 @@
 @interface KPURLProtocol : NSURLProtocol
 +(void)enable;
 +(void)disable;
++(void)ignoreLocalCacheForRequest:(NSMutableURLRequest*)request;
 @end


### PR DESCRIPTION
The mechanism is explained inside. This is an internal API anyway.
