### PR TITLE
Feature/kp controls wk webview

### DIFF
--- a/KALTURAPlayerSDK/KPControlsView.m
+++ b/KALTURAPlayerSDK/KPControlsView.m
@@ -9,7 +9,7 @@
 #import "KPControlsView.h"
 #import "DeviceParamsHandler.h"
 
-#define KP_CONTROLS_WEBVIEW  SYSTEM_VERSION_EQUAL_TO(@"7") ? @"KPControlsUIWebview" : @"KPControlsWKWebview"
+#define KP_CONTROLS_WEBVIEW  SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10") ? @"KPControlsWKWebview" : @"KPControlsUIWebview"
 
 NSString *sendNotification(NSString *notification, NSString *params) {
     return [NSString stringWithFormat:@"NativeBridge.videoPlayer.sendNotification(\"%@\" ,%@);", notification, params];

--- a/KALTURAPlayerSDK/KPControlsView.m
+++ b/KALTURAPlayerSDK/KPControlsView.m
@@ -37,6 +37,6 @@ NSString *showChromecastComponent(BOOL show) {
 
 @implementation KPControlsView
 + (id<KPControlsView>)defaultControlsViewWithFrame:(CGRect)frame {
-    return (id<KPControlsView>)[[NSClassFromString(@"KPControlsUIWebview") alloc] initWithFrame:frame];
+    return (id<KPControlsView>)[[NSClassFromString(KP_CONTROLS_WEBVIEW) alloc] initWithFrame:frame];
 }
 @end

--- a/KPlayerResources/Info.plist
+++ b/KPlayerResources/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.5</string>
+	<string>2.3.6</string>
 	<key>CFBundleSignature</key>
 	<string></string>
 	<key>CFBundleVersion</key>
-	<string>2.3.5</string>
+	<string>2.3.6</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/KPlayerResources/Info.plist
+++ b/KPlayerResources/Info.plist
@@ -15,11 +15,19 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
+<<<<<<< f687a663c823b81a118aa15518c9af550275a6e0
 	<string>2.3.6</string>
 	<key>CFBundleSignature</key>
 	<string></string>
 	<key>CFBundleVersion</key>
 	<string>2.3.6</string>
+=======
+	<string>2.4.0</string>
+	<key>CFBundleSignature</key>
+	<string></string>
+	<key>CFBundleVersion</key>
+	<string>2.4.0</string>
+>>>>>>> bump v2.4.0
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/KalturaPlayerSDK.podspec
+++ b/KalturaPlayerSDK.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
 
 # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 s.name         = "KalturaPlayerSDK"
-s.version      = "2.4.2-dev"
+s.version      = "2.3.6"
 s.summary      = "The Kaltura player-sdk-native component enables embedding the kaltura player into native environments."
 
 #s.description  = <<-DESC
@@ -34,24 +34,30 @@ s.platform     = :ios, "8.0"
 
 # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 s.source       = { :git => 'https://github.com/kaltura/player-sdk-native-ios.git', :tag => 'v' + s.version.to_s }
-s.libraries      = 'stdc++', 'z', 'System', 'stdc++.6', 'xml2.2', 'c++', 'stdc++.6.0.9', 'xml2'
+s.libraries      = 'stdc++', 'z', 'System', 'stdc++.6', 'xml2.2', 'c++', 'stdc++.6.0.9', 'xml2', 'WViPhoneAPI'
 s.framework    = 'MediaPlayer', 'SystemConfiguration', 'QuartzCore', 'CoreFoundation', 'AVFoundation', 'AudioToolbox', 'CFNetwork', 'AdSupport', 'WebKit', 'MessageUI', 'Social', 'MediaAccessibility', 'Foundation', 'CoreGraphics', 'UIKit'
 
 s.requires_arc = true
 
 
-s.subspec 'Core' do |sp|
-    sp.source_files  = "**/*.{h,m}", "PlayerSDK/KALTURAPlayerSDK/**/*.{h,m}"
-    sp.resource_bundle = { 'KALTURAPlayerSDKResources' => 'KALTURAPlayerSDK/*.{xib,plist}' }
+# ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+s.source_files  = "**/*.{h,m}", "PlayerSDK/KALTURAPlayerSDK/**/*.{h,m}"
+s.vendored_library = 'libWViPhoneAPI.a'
+s.resource_bundle = { 'KALTURAPlayerSDKResources' => 'KALTURAPlayerSDK/*.{xib,plist}' }
+#s.exclude_files = "Classes/Exclude"
+
+# ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+#
+#  A list of resources included with the Pod. These are copied into the
+#  target bundle with a build phase script. Anything else will be cleaned.
+#  You can preserve files from being cleaned, please don't preserve
+#  non-essential files like tests, examples and documentation.
+#
+
+# s.resource  = "icon.png"
+# s.resources = "Resources/*.png"
+
+# s.preserve_paths = "FilesToSave", "MoreFilesToSave"
+
+s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
 end
-
-s.subspec 'Widevine' do |sp|
-    sp.libraries = 'WViPhoneAPI'
-    sp.vendored_library = 'libWViPhoneAPI.a'
-    sp.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO', 'GCC_PREPROCESSOR_DEFINITIONS'=>'WIDEVINE_ENABLED=1' }
-end
-
-end
-
-
-

--- a/KalturaPlayerSDK.podspec
+++ b/KalturaPlayerSDK.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
 
 # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 s.name         = "KalturaPlayerSDK"
-s.version      = "2.3.6"
+s.version      = "2.4.0"
 s.summary      = "The Kaltura player-sdk-native component enables embedding the kaltura player into native environments."
 
 #s.description  = <<-DESC


### PR DESCRIPTION
Returns the result of running a JavaScript script. Although this method is not deprecated, best practice is to use the evaluateJavaScript:completionHandler: method of the WKWebView class instead.
New apps should instead use the evaluateJavaScript:completionHandler: method from the WKWebView class. Legacy apps should adopt that method if possible.