### PR TITLE
TPE-23 IOS: App crashes when play video after start casting.

### DIFF
--- a/KALTURAPlayerSDK/GoogleCastProvider.m
+++ b/KALTURAPlayerSDK/GoogleCastProvider.m
@@ -330,10 +330,19 @@ didReceiveTextMessage:(NSString *)message
             NSString *thumbnailUrl = @"";
             NSString *description = @"";
             
-            id media_id = [[[dictionary objectForKey:@"partnerData"] objectForKey:@"requestData"] objectForKey:@"MediaID"];
+            id media_id = nil;
             
-            if (!mediaId || [(NSString *)mediaId isEqualToString:@""]) {
-                id media_id = [dictionary objectForKey:@"id"];
+            id partner_data = [dictionary objectForKey:@"partnerData"];
+            if ([partner_data isKindOfClass: [NSDictionary class]]) {
+                //OTT
+                id requestData = [((NSDictionary *)partner_data) objectForKey: @"requestData"];
+                if ([requestData isKindOfClass: [NSDictionary class]]) {
+                    
+                    media_id = [((NSDictionary *)requestData) objectForKey: @"MediaID"];
+                }
+            } else {
+                //OVP
+                mediaId =  [dictionary objectForKey:@"id"];
             }
             
             if ([media_id isKindOfClass: [NSString class]]) {


### PR DESCRIPTION
Is reproduced with KPlayer SDK v.2.5.0.rc.6 and mwEmbed v.2.48.6.
Precondition: there should not be cast sessions running on chromecast. If chromecast is connected please stop casting.
1. Connect to Chromecast using cast button of Google cast SDK.
2. Open player and start playing video.
Actual result: After a few seconds we observe a crash in file GoogleCastProvider.m line 265.
Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSNull objectForKey:]: unrecognized selector sent to instance 0x1b2a59ef8'
To work with Kaltura castProvider we are using the following code:
-(void)kPlayer:(KPViewController *)player playerPlaybackStateDidChange:(KPMediaPlaybackState)state {
    switch (state) {
        case KPMediaPlaybackStatePlaying: {
            [self.delegate playerAdapterDidResume];
            if (!self.playerVC.castProvider) {
                self.playerVC.castProvider = self.chromecastListener.castProvider;
            }
            break;
        }
.......
   }
}

We are not calling any method of GoogleCastProvider from any other place inside our code. Should we do something more on our side?
We expect that if we start the video after connection with chromecast was established it should automatically start playing on chromecast.