### PR TITLE
Feature/FEM 865 entryid

### DIFF
--- a/KALTURAPlayerSDK/GoogleCastProvider.m
+++ b/KALTURAPlayerSDK/GoogleCastProvider.m
@@ -379,7 +379,7 @@ didReceiveTextMessage:(NSString *)message
             metadata = [[GCKMediaMetadata alloc] initWithMetadataType:GCKMediaMetadataTypeMovie];
             [metadata setString: title forKey:kGCKMetadataKeyTitle];
             [metadata setString: description forKey:kGCKMetadataKeySubtitle];
-            [metadata setString: mediaId forKey: @"KEY_ENTRY_ID"];
+            [metadata setString: mediaId forKey: @"entryid"];
             
             [metadata addImage:[[GCKImage alloc] initWithURL:[NSURL URLWithString:thumbnailUrl]
                                                        width:480


### PR DESCRIPTION
In 2.6.2 sdk  also "KEY_ENTRY_ID" is used in GoogleCastProvider.. Kindly use "entryid"