### PR TITLE
TPE-50 iOS Chromecast: Unstable crash on changing media.

### DIFF
--- a/KALTURAPlayerSDK/KPViewController.m
+++ b/KALTURAPlayerSDK/KPViewController.m
@@ -1030,9 +1030,13 @@ NSString *const KPErrorDomain = @"com.kaltura.player";
     
     [self asyncEvaluate:@"{mediaProxy.entry}" expressionID:@"MediaProxy" handler:^(NSString *value) {
         
-        if (handler != nil && value.length > 0) {
+        BOOL valueIsString = [value isKindOfClass: [NSString class]];
+        if (valueIsString) {
             
-            handler(value);
+            if (handler != nil && value.length > 0) {
+                
+                handler(value);
+            }
         }
     }];
 }


### PR DESCRIPTION
We found a case which causes app crash on changing media after
returning from background. The scenario is following:
1. Play some video on Chromecast.
2. Go to the background with your app until the video plays to the end
on Chromecast (wait until the logo is displayed).
3. Switch back to your app from the background.
4. Try to start another video.
Actual result:
App crashes. The issue is not stable and can't be 100% reproduced.
It may happen when changing medias many times even when not going to
background with app.
Crash happens in KPViewController.m line 1033.
- (void)startCastingWithHandler:(void (^)(NSString *))handler {

[self asyncEvaluate:@"{mediaProxy.entry}"
expressionID:@"MediaProxy" handler:^(NSString *value) {

if (handler != nil && value.length > 0) {

handler(value);
}
}];
}
In this case variable "value" comes with NSNull class what causes and
issue "
[NSNull length]
: unrecognized selector sent to instance 0x1b89d9ef8'"