### PR TITLE
Problem with mid-roll ads and iOS Player SDK

### DIFF
--- a/KALTURAPlayerSDK/IMAHandler.h
+++ b/KALTURAPlayerSDK/IMAHandler.h
@@ -17,10 +17,12 @@
 
 @end
 
+@protocol AVPlayerContentPlayhead;
 @protocol AdsRequest <NSObject>
 
 - (instancetype)initWithAdTagUrl:(NSString *)adTagUrl
               adDisplayContainer:(id<AdDisplayContainer>)adDisplayContainer
+                 contentPlayhead:(id<AVPlayerContentPlayhead>)contentPlayhead
                      userContext:(id)userContext;
 
 @end

--- a/KALTURAPlayerSDK/KPIMAPlayerViewController.m
+++ b/KALTURAPlayerSDK/KPIMAPlayerViewController.m
@@ -57,10 +57,10 @@
     
     // Load AVPlayer with path to our content.
     self.contentPlayer = contentPlayer;
-    id<AdsRequest> request = [[NSClassFromString(@"IMAAdsRequest") alloc] initWithAdTagUrl:adLink
-                                                                        adDisplayContainer:self.adDisplayContainer
-                                                                               userContext:nil];
     
+    // Set up our content playhead and contentComplete callback.
+    id<AdsRequest> request = [[NSClassFromString(@"IMAAdsRequest") alloc] initWithAdTagUrl: adLink adDisplayContainer: self.adDisplayContainer contentPlayhead: self.playhead userContext: nil];
+
     [self.adsLoader requestAdsWithRequest:request];
 }
 
@@ -151,8 +151,6 @@
     }
     return _playhead;
 }
-
-
 
 #pragma mark IMAAdsLoaderDelegate
 - (void)adsLoader:(id<AdsLoader>)loader adsLoadedWithData:(id<AdsLoadedData>)adsLoadedData {


### PR DESCRIPTION
The issue:
Carbon reported on the following error when playing entry with mid
rolls on their IOS app:
"AdsManager error: Content playhead was not used, but ad playlist
served."
Below are two video examples with their embed codes and the ad tags:
embedCode: 0_ju11tdjy Behind The Draw
adTag:
https://pubads.g.doubleclick.net/gampad/ads?sz=400x300&iu=/6544/CTV_Mobi
le_App/CTV_Mobile_App_400x300v&impl=s&gdfp_req=1&env=vp&output=xml_vast2
&unviewed_position_start=1&url=[referrer_url]&description_url=[descripti
on_url]&correlator=[timestamp]&cmsid=5858&ad_rule=1&vid=0_ju11tdjy&show=
behind%20the%20draw
AdsManager error: Content playhead was not used, but ad playlist served.
embedCode: 0_uxsvqnak Till Death Do Us Part
adTag:
https://pubads.g.doubleclick.net/gampad/ads?sz=400x300&iu=/6544/CTV_Mobi
le_App/CTV_Mobile_App_400x300v&impl=s&gdfp_req=1&env=vp&output=xml_vast2
&unviewed_position_start=1&url=[referrer_url]&description_url=[descripti
on_url]&correlator=[timestamp]&cmsid=5858&ad_rule=1&vid=0_uxsvqnak&show=
till%20death%20do%20us%20part
AdsManager error: Content playhead was not used, but ad playlist served.
Additional information:
player Id: 36925651
The player SDK version is 2.6.4