### PR TITLE
added 'KP' prefix to the 'notifyListener' function to avoid collisions

### DIFF
--- a/KALTURAPlayerSDK/KPLog.h
+++ b/KALTURAPlayerSDK/KPLog.h
@@ -16,7 +16,7 @@ extern NSString *const KPLogMessageLevelKey;
 
 
 void _KPLog(KPLogLevel logLevel, NSString *methodName, int lineNumber, NSString *format, ...);
-void notifyListener(NSString *message, NSInteger messageLevel);
+void KPNotifyListener(NSString *message, NSInteger messageLevel);
 
 #ifdef DEBUG
 #define __FileName__ [[NSString stringWithUTF8String:__FILE__] lastPathComponent]

--- a/KALTURAPlayerSDK/KPLog.m
+++ b/KALTURAPlayerSDK/KPLog.m
@@ -14,14 +14,14 @@ void _KPLog(KPLogLevel logLevel,  NSString *methodName, int lineNumber,NSString 
     format = [NSString stringWithFormat:@"::%@:: %@ (line:%d) -- %@",KPLogManager.levelNames[logLevel / 10], methodName, lineNumber,format];
     va_list args;
     va_start(args, format);
-    notifyListener([[[NSString alloc] initWithFormat:format arguments:args] init], logLevel);
+    KPNotifyListener([[[NSString alloc] initWithFormat:format arguments:args] init], logLevel);
     va_end(args);
     va_start(args, format);
     NSLogv(format, args);
     va_end(args);
 }
 
-void notifyListener(NSString *message, NSInteger messageLevel) {
+void KPNotifyListener(NSString *message, NSInteger messageLevel) {
     [[NSNotificationCenter defaultCenter] postNotificationName:KPLoggingNotification
                                                         object:nil
                                                       userInfo:@{KPLogMessageKey: message,


### PR DESCRIPTION
Appnexus iOS SDK contains function with the same name
https://github.com/appnexus/mobile-sdk-ios/blob/master/sdk/internal/ANLogging.h

C function declarations should be namespaced just like a class