### PR TITLE
Feature/TPE 52

### DIFF
--- a/KALTURAPlayerSDK/KPCastProvider.h
+++ b/KALTURAPlayerSDK/KPCastProvider.h
@@ -14,6 +14,7 @@
 - (void)castPlayerState:(NSString *)state;
 - (void)startCasting;
 - (void)stopCasting;
+- (void)restartCurrentCasting;
 
 @end
 

--- a/KALTURAPlayerSDK/KPControlsView.m
+++ b/KALTURAPlayerSDK/KPControlsView.m
@@ -35,7 +35,7 @@ NSString *showChromecastComponent(BOOL show) {
 
 @implementation KPControlsView
 + (id<KPControlsView>)defaultControlsViewWithFrame:(CGRect)frame {
-    NSString *webViewType = @"KPControlsUIWebview";
+    NSString *webViewType = ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion >= 10) ?  @"KPControlsWKWebview" : @"KPControlsUIWebview";
     return (id<KPControlsView>)[[NSClassFromString(webViewType) alloc] initWithFrame:frame];
 }
 @end

--- a/KALTURAPlayerSDK/KPControlsWKWebView.m
+++ b/KALTURAPlayerSDK/KPControlsWKWebView.m
@@ -144,6 +144,7 @@
         NSLog(@"HTTP:: %@", requestString);
     }
     decisionHandler(WKNavigationActionPolicyAllow);
+
 }
 
 - (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error {

--- a/KALTURAPlayerSDK/KPViewController.m
+++ b/KALTURAPlayerSDK/KPViewController.m
@@ -377,6 +377,7 @@ NSString *const KPErrorDomain = @"com.kaltura.player";
             [strongSelf triggerCastEvent:castProvider];
         }];
         
+        [self restartCurrentMedia];
         KPLogTrace(@"Exit setCastProvider");
         return;
     }
@@ -387,6 +388,7 @@ NSString *const KPErrorDomain = @"com.kaltura.player";
     [self triggerCastEvent:castProvider];
     _playerFactory.lastPlayBackTime = _playerFactory.currentPlayBackTime;
     
+    [self restartCurrentMedia];
     KPLogTrace(@"Exit setCastProvider");
 }
 
@@ -1022,6 +1024,8 @@ NSString *const KPErrorDomain = @"com.kaltura.player";
     [self player:currentPlayer eventName:EndedKey value:nil];
 }
 
+#pragma mark - Factory
+
 - (void)allAdsCompleted {
     [self.controlsView triggerEvent:AllAdsCompletedKey withJSON:nil];
 }
@@ -1040,6 +1044,17 @@ NSString *const KPErrorDomain = @"com.kaltura.player";
         }
     }];
 }
+
+- (void)restartCurrentMedia {
+    
+    if (_currentConfiguration) {
+        if (_currentConfiguration.entryId != nil) {
+            [self changeMedia: _currentConfiguration.entryId];
+        }
+    }
+}
+
+#pragma mark -
 
 - (void)triggerKPlayerNotification: (NSNotification *)note{
     KPLogTrace(@"Enter");

--- a/KALTURAPlayerSDK/KPlayerFactory.h
+++ b/KALTURAPlayerSDK/KPlayerFactory.h
@@ -32,6 +32,7 @@ static NSString *PostrollEndedKey = @"postEnded";
 @protocol KPlayerFactoryDelegate <KPlayerDelegate>
 - (void)allAdsCompleted;
 - (void)startCastingWithHandler:(void(^)(NSString *value))handler;
+- (void)restartCurrentMedia;
 @end
 
 @interface KPlayerFactory : NSObject 

--- a/KALTURAPlayerSDK/KPlayerFactory.m
+++ b/KALTURAPlayerSDK/KPlayerFactory.m
@@ -261,6 +261,11 @@ typedef NS_ENUM(NSInteger, CurrentPlyerType) {
     [self play];
 }
 
+- (void)restartCurrentCasting {
+    
+    [_delegate restartCurrentMedia];
+}
+
 - (void)updateCastState:(NSString *)state {
     isPlaying = _player.isPlaying;
     [_delegate player:_player eventName:state value:nil];


### PR DESCRIPTION
I have checked the issue with our app and with the last demo app and for me it is still reproducible. The problem happens when on the beginning of loading on chromecast when message "Loading Kaltura player on Chromecast..." just appeared quickly go to the background.
When come back to app this massage still is displayed and not disappearing, player controls are not available.
I have used Kaltura player SDK v.2.6.8 and mwEmbed 2.51 for testing.